### PR TITLE
Add `ensure` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aeiou",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "i18n scripts",
   "engines": {
     "node": ">=8.4.0"

--- a/src/aeiou.ts
+++ b/src/aeiou.ts
@@ -20,7 +20,7 @@ yargs
         yargs.option('password', { describe: 'transifex 비밀번호', type: 'string', demandOption: true });
         yargs.option('project', { describe: 'transifex 프로젝트', type: 'string', demandOption: true });
         yargs.option('resource', { describe: 'transifex 리소스', type: 'string', demandOption: true });
-        yargs.option('potDir', { describe: 'messages.pot 경로', type: 'string', demandOption: true });
+        yargs.option('potDir', { describe: 'messages.pot 파일이 들어있는 디렉토리', type: 'string', demandOption: true });
         return yargs;
     }, async argv => {
         const { id, password, project, resource, potDir } = argv;

--- a/src/aeiou.ts
+++ b/src/aeiou.ts
@@ -3,6 +3,7 @@ import * as yargs from 'yargs';
 import extract from './commands/extract';
 import push from './commands/push';
 import download from './commands/download';
+import ensure from './commands/ensure';
 
 
 yargs
@@ -36,6 +37,15 @@ yargs
     }, async argv => {
         const { id, password, project, resource, outDir } = argv;
         await download(id, password, project, resource, outDir);
+    })
+    .command('ensure', '현재 프로젝트에서 특정 로케일로의 번역이 모두 이루어졌는지 확인합니다. (extract, download 이후 사용)', yargs => {
+        yargs.option('locale', { describe: '확인하고 싶은 로케일', type: 'string' });
+        yargs.option('potDir', { describe: 'messages.pot 이 저장되어 있는 디렉토리', type: 'string', demandOption: true });
+        yargs.option('poDir', { describe: '번역 파일들이 저장되어 있는 디렉토리 (생략시 potDir과 동일)', type: 'string' });
+        return yargs;
+    }, async argv => {
+        const { locale, potDir, poDir } = argv;
+        await ensure(locale, potDir, poDir || potDir);
     })
     .strict()
     .demandCommand(1, '명령을 입력해주세요.')

--- a/src/commands/ensure.ts
+++ b/src/commands/ensure.ts
@@ -16,11 +16,16 @@ export default async function ensure(
 
     for (let [context, translations] of Object.entries(template.translations)) {
         const localeTranslations = localeCatalog.translations[context];
+        if (localeTranslations == null) {
+            untranslatedMsgs.push(...Object.keys(translations).map(
+                msgid => [context, msgid] as [string, string]
+            ));
+            continue;
+        }
 
         for (let msgid of Object.keys(translations)) {
-            const { msgstr } = localeTranslations[msgid];
-
-            if (msgstr.every(str => str === '')) {
+            const translation = localeTranslations[msgid];
+            if (translation == null || translation.msgstr.every(str => str === '')) {
                 untranslatedMsgs.push([context, msgid]);
             }
         }
@@ -30,7 +35,7 @@ export default async function ensure(
         console.error([
             `There are ${untranslatedMsgs.length} untranslated messages:`,
             '',
-            ...untranslatedMsgs.map(([context, msgid]) => `msgid: ${msgid}, msgctxt: ${context}`)
+            ...untranslatedMsgs.map(([context, msgid]) => `msgid: ${msgid}${context && `, msgctxt: ${context}`}`),
         ].join('\n'));
         process.exit(untranslatedMsgs.length);
     }

--- a/src/commands/ensure.ts
+++ b/src/commands/ensure.ts
@@ -1,0 +1,39 @@
+import { join } from 'path';
+
+import { Catalog } from '../extract';
+import { readFileAsync } from '../file';
+
+
+export default async function ensure(
+    locale: string,
+    potDir: string,
+    poDir: string,
+) {
+    const untranslatedMsgs: Array<[string, string]> = [];
+
+    const template = Catalog.from(await readFileAsync(join(potDir, 'messages.pot'), 'utf8') as string);
+    const localeCatalog = Catalog.from(await readFileAsync(join(poDir, `${locale}.po`), 'utf8') as string);
+
+    for (let [context, translations] of Object.entries(template.translations)) {
+        const localeTranslations = localeCatalog.translations[context];
+
+        for (let msgid of Object.keys(translations)) {
+            const { msgstr } = localeTranslations[msgid];
+
+            if (msgstr.every(str => str === '')) {
+                untranslatedMsgs.push([context, msgid]);
+            }
+        }
+    }
+
+    if (untranslatedMsgs.length > 0) {
+        console.error([
+            `There are ${untranslatedMsgs.length} untranslated messages:`,
+            '',
+            ...untranslatedMsgs.map(([context, msgid]) => `msgid: ${msgid}, msgctxt: ${context}`)
+        ].join('\n'));
+        process.exit(untranslatedMsgs.length);
+    }
+
+    console.log('All message translated.');
+}

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,3 +1,5 @@
+import { join } from 'path';
+
 import { putSourceLanguage } from '../transifex';
 import { Catalog } from '../extract';
 import { readFileAsync } from '../file';
@@ -12,6 +14,6 @@ export default async function push(
 ) {
     // transifex는 새로 생긴 번역어만 추가하고, 나머지는 신경쓰지 않기 때문에
     // 기존 문구들과 병합하는 처리가 따로 필요하지 않습니다.
-    const catalog = Catalog.from(await readFileAsync(potDir, 'utf8') as string);
+    const catalog = Catalog.from(await readFileAsync(join(potDir, 'messages.pot'), 'utf8') as string);
     await putSourceLanguage(id, password, project, resource, catalog.toString());
 }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -56,7 +56,7 @@ export interface Translation {
     };
 }
 export interface Context {
-    [translation: string]: Translation;
+    [msgid: string]: Translation;
 }
 export interface Translations {
     [context: string]: Context;


### PR DESCRIPTION
현재 리포지토리에서 추출한 번역어와 transifex에 들어 있는 번역어를 대조해서 번역이 안 된 메시지가 있으면 non-zero exit code 를 내뿜는 `ensure` 커맨드를 추가합니다.